### PR TITLE
Adds a filter for CURL options set for the Google_IO_Curl class.

### DIFF
--- a/tools/gapi.php
+++ b/tools/gapi.php
@@ -41,7 +41,7 @@ if ( ! class_exists( 'GADWP_GAPI_Controller' ) ) {
 				if ( isset( $curlversion['version'] ) && ( version_compare( PHP_VERSION, '5.3.0' ) >= 0 ) && version_compare( $curlversion['version'], '7.10.8' ) >= 0 && defined( 'GADWP_IP_VERSION' ) && GADWP_IP_VERSION ) {
 					$curl_options[CURLOPT_IPRESOLVE] = GADWP_IP_VERSION; // Force CURL_IPRESOLVE_V4 or CURL_IPRESOLVE_V6
 				}
-				$curl_options = apply_filters( 'gadwp_curl_options', array() );
+				$curl_options = apply_filters( 'gadwp_curl_options', $curl_options );
 				if ( !empty( $curl_options ) ) {
 					$config->setClassConfig( 'Google_IO_Curl', array( 'options' => $curl_options ) );
 				}

--- a/tools/gapi.php
+++ b/tools/gapi.php
@@ -37,8 +37,13 @@ if ( ! class_exists( 'GADWP_GAPI_Controller' ) ) {
 			$config->setCacheClass( 'Google_Cache_Null' );
 			if ( function_exists( 'curl_version' ) ) {
 				$curlversion = curl_version();
+				$curl_options = array();
 				if ( isset( $curlversion['version'] ) && ( version_compare( PHP_VERSION, '5.3.0' ) >= 0 ) && version_compare( $curlversion['version'], '7.10.8' ) >= 0 && defined( 'GADWP_IP_VERSION' ) && GADWP_IP_VERSION ) {
-					$config->setClassConfig( 'Google_IO_Curl', array( 'options' => array( CURLOPT_IPRESOLVE => GADWP_IP_VERSION ) ) ); // Force CURL_IPRESOLVE_V4 or CURL_IPRESOLVE_V6
+					$curl_options[CURLOPT_IPRESOLVE] = GADWP_IP_VERSION; // Force CURL_IPRESOLVE_V4 or CURL_IPRESOLVE_V6
+				}
+				$curl_options = apply_filters( 'gadwp_curl_options', array() );
+				if ( !empty( $curl_options ) ) {
+					$config->setClassConfig( 'Google_IO_Curl', array( 'options' => $curl_options ) );
 				}
 			}
 			$this->client = new Google_Client( $config );


### PR DESCRIPTION
We have a very particular situation in our server environment: the CA certificates file [included in the Google Client library](https://github.com/deconf/Google-Analytics-Dashboard-for-WP/blob/master/tools/src/Google/IO/cacerts.pem) prevents SSL connections from working. This file is used instead of CURL's default because of an option set at [line 73 here](https://github.com/deconf/Google-Analytics-Dashboard-for-WP/blob/master/tools/src/Google/IO/Curl.php#L73). 

As you can see, if the option was already set before then, it would be honored. So what we would need is a way to set our own options to the Google_IO_Curl class before any request is sent with it. This PR adds a filter that allows just this. It has no other side-effects, I hope.