### PR TITLE
fix for links in inline SVGs

### DIFF
--- a/front/js/tracking-analytics-events.js
+++ b/front/js/tracking-analytics-events.js
@@ -29,8 +29,10 @@ jQuery( window ).on( 'load', function () {
 	if ( gadwpUAEventsData.options[ 'event_tracking' ] ) {
 		// Track Downloads
 		jQuery( 'a' ).filter( function () {
-			var reg = new RegExp( '.*\\.(' + gadwpUAEventsData.options[ 'event_downloads' ] + ')(\\?.*)?$' );
-			return this.href.match( reg );
+            if (typeof this.href === 'string') {
+                var reg = new RegExp( '.*\\.(' + gadwpUAEventsData.options[ 'event_downloads' ] + ')(\\?.*)?$' );
+                return this.href.match( reg );
+            }
 		} ).click( function ( e ) {
 			var category = this.getAttribute( 'data-vars-ga-category' ) || 'download';
 			var action = this.getAttribute( 'data-vars-ga-action' ) || 'click';


### PR DESCRIPTION
Inline SVG `<a>` elements technically should use `xlink:href` rather than `href` attributes, and `this.href.match` is causing an `Uncaught TypeError` on SVG `<a>` elements:
![screen shot 2017-10-16 at 12 16 58 pm](https://user-images.githubusercontent.com/784333/31622973-f6bcda60-b26b-11e7-816c-1d02b6bdb987.png)
