### PR TITLE
Add filters for customization of gtag() output, allowing custom parameters and events to be inserted

### DIFF
--- a/front/tracking-analytics.php
+++ b/front/tracking-analytics.php
@@ -465,6 +465,10 @@ if ( ! class_exists( 'AIWP_Tracking_GlobalSiteTag' ) ) {
 			$this->build_commands();
 			$trackingcode = '';
 			foreach ( $this->commands as $set ) {
+				
+				// Use this filter to insert properties into $set['fieldsobject']
+				$set = apply_filters('aiwp_gtag_command', $set, $this);
+				
 				$command = $set['command'];
 				$fields = '';
 				foreach ( $set['fields'] as $fieldkey => $fieldvalue ) {

--- a/front/views/analytics-code.php
+++ b/front/views/analytics-code.php
@@ -25,8 +25,12 @@
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-<?php echo wp_kses( $data['trackingcode'], array() )?>
-
+<?php
+// Use these actions to insert gtag() commands before/after the main gtag('config') for the tracker
+do_action('aiwp_output_globalsitetag_trackingcode_before');
+echo wp_kses( $data['trackingcode'], array() );
+do_action('aiwp_output_globalsitetag_trackingcode_after');
+?>
   if (window.performance) {
     var timeSincePageLoad = Math.round(performance.now());
     gtag('event', 'timing_complete', {


### PR DESCRIPTION
Thank you for this plugin, it does so much of what I need, but our project also requires some elements that are probably beyond the scope of your plugin, which is fine! 

I am willing to create the JS for my customizations to the gtag() output from my own PHP plugin, and all I need are some small actions and filters in your code so I can hook into the correct place. I think these could be valuable to a lot of developers, and that your plugin is the perfect one for developers like me to build upon, as long as there are some hooks so we can create customized extensions. 

This PR has two separate commits, sorry about that, I'm not that good at PRs. 

The first one adds a filter during the setup of the `gtag('config')` command, so that I can insert custom parameters (dimensions) based on my own needs. This one is kind of weird because the code that's being filtered probably wasn't designed to have other people using it, but it works, as you can see in the demo code below. 

The second one adds two actions in the actual output of the gtag code, one before and one after the main `gtag('config')` command for the tracker. I think having both present is important because some things may only work before or after (such as the `gtag('set')` command only working before the `gtag('config')` command). So far I am using these hooks to insert a second tracker, and to insert custom events based on jQuery, but there are many other uses I might make of them, as long as I have a spot to insert code. In the example below I insert a custom click event in the `*_after` action.

In both cases, these are just the simplest, most minimal ways of achieving what I need. I'm sure you could make them more elegant and fitting with your coding style if you wanted, so of course feel free to change them any way you need to. As long as I can insert custom parameters into the config command, and insert arbitrary JS before/after the config command, I will be extremely happy!

Here is my demo plugin that demonstrates both changes:

```
<?php
/**
 * Plugin Name: AIWP Jer's Filter Demo
 * Plugin URI: https://jerclarke.org
 * Description: Simple demo of the filters Jer is proposing to add to AIWP
 * Author: Jer Clarke
 * Version: 0.1
 * Author URI: https://jerclarke.org
 * Text Domain: jer-demo
 * Domain Path: /languages
 */

// Insert a custom parameter into the gtag('config') command
function jer_demo_insert_global_parameters($command_array, AIWP_Tracking_GlobalSiteTag $aiwp_tracker) {
	
	$command_array['fieldsobject']['demo_parameter'] = 'demo_value';
	
	return $command_array;
}
add_filter('aiwp_gtag_command', 'jer_demo_insert_global_parameters', 10, 2 );

// Add a custom click event with gtag('event') right after the tracker is registered
function demo_insert_ga_events_after_gtag() {
	
	$output = "
	jQuery(document).ready(function($) {
		$('body').on('click', '.entry-title', function() {
			gtag('event', 'select_content', {
			   'content_type': 'entry_title'
			});
		});
	});
	";
	
	echo $output;
}
add_action('aiwp_output_globalsitetag_trackingcode_after', 'demo_insert_ga_events_after_gtag');
```

Thank you so much for your consideration, and once again for all the work you do on this plugin!
